### PR TITLE
Add Hostname field

### DIFF
--- a/horenso.go
+++ b/horenso.go
@@ -35,13 +35,16 @@ type Report struct {
 	Pid         int        `json:"pid"`
 	StartAt     *time.Time `json:"startAt,omitempty"`
 	EndAt       *time.Time `json:"endAt,omitempty"`
+	Hostname    string     `json:"hostname"`
 }
 
 func (o *opts) run(args []string) (Report, error) {
+	hostname, _ := os.Hostname()
 	r := Report{
 		Command:     shellquote.Join(args...),
 		CommandArgs: args,
 		Tag:         o.Tag,
+		Hostname:    hostname,
 	}
 	cmd := exec.Command(args[0], args[1:]...)
 

--- a/horenso_test.go
+++ b/horenso_test.go
@@ -3,6 +3,7 @@ package horenso
 import (
 	"encoding/json"
 	"io/ioutil"
+	"os"
 	"reflect"
 	"testing"
 )
@@ -69,6 +70,10 @@ func TestRun(t *testing.T) {
 	if r.EndAt == nil {
 		t.Errorf("EtartAt shouldn't be nil")
 	}
+	expected_hostname, _ := os.Hostname()
+	if r.Hostname != expected_hostname {
+		t.Errorf("Hostname should be %s but: %s", expected_hostname, r.Hostname)
+	}
 
 	rr := parseReport(fname)
 	if !deepEqual(r, rr) {
@@ -95,6 +100,9 @@ func TestRun(t *testing.T) {
 	if nr.ExitCode != nil {
 		t.Errorf("ExitCode should be nil")
 	}
+	if nr.Hostname != r.Hostname {
+		t.Errorf("something went wrong")
+	}
 }
 
 func deepEqual(r1, r2 Report) bool {
@@ -106,5 +114,6 @@ func deepEqual(r1, r2 Report) bool {
 		r1.Stderr == r2.Stderr &&
 		*r1.ExitCode == *r2.ExitCode &&
 		r1.Result == r2.Result &&
-		r1.Pid == r2.Pid
+		r1.Pid == r2.Pid &&
+		r1.Hostname == r2.Hostname
 }

--- a/horenso_test.go
+++ b/horenso_test.go
@@ -70,9 +70,9 @@ func TestRun(t *testing.T) {
 	if r.EndAt == nil {
 		t.Errorf("EtartAt shouldn't be nil")
 	}
-	expected_hostname, _ := os.Hostname()
-	if r.Hostname != expected_hostname {
-		t.Errorf("Hostname should be %s but: %s", expected_hostname, r.Hostname)
+	expectedHostname, _ := os.Hostname()
+	if r.Hostname != expectedHostname {
+		t.Errorf("Hostname should be %s but: %s", expectedHostname, r.Hostname)
 	}
 
 	rr := parseReport(fname)


### PR DESCRIPTION
Hi,

I added a feature to pass hostname from horenso to handlers. noticer and reporter can know it's hostname without writing like `os.Hostname()` in each reporter/noticer. 

Is this feature useful in common usage?