### PR TITLE
cmd.Start() before stdinPipe.Write()

### DIFF
--- a/_testdata/run_hugeoutput.go
+++ b/_testdata/run_hugeoutput.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+func main() {
+	// output 64K + 1 bytes
+	for i := 0; i < 1024; i++ {
+		fmt.Print(strings.Repeat("x", 63), "\n")
+	}
+	fmt.Print("\n")
+}

--- a/horenso.go
+++ b/horenso.go
@@ -184,9 +184,17 @@ func runHandler(cmdStr string, json []byte) ([]byte, error) {
 	}
 	cmd := exec.Command(args[0], args[1:]...)
 	stdinPipe, _ := cmd.StdinPipe()
+	var b bytes.Buffer
+	cmd.Stdout = &b
+	cmd.Stderr = &b
+	if err := cmd.Start(); err != nil {
+		stdinPipe.Close()
+		return b.Bytes(), err
+	}
 	stdinPipe.Write(json)
 	stdinPipe.Close()
-	return cmd.CombinedOutput()
+	err = cmd.Wait()
+	return b.Bytes(), err
 }
 
 func runHandlers(handlers []string, json []byte) {


### PR DESCRIPTION
I've experienced horenso could not run reporters and running forever, after the command was completed with huge output (more than about 32KB).

for example

```
$ horenso -r cat -- perl -E 'say "x" x 32768'
xxxxx
....
xxxxx
(horenso running forever)
```

cmd.CombinedOutput() calls cmd.Start() and cmd.Wait().
stdinPipe.Write() will be blocked when write byte size is more than pipe buffer, because cmd is not started.
