### PR TITLE
Add Go 1.6, 1.7, and tip to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: go
 go:
-  - 1.5
-  - 1.6
   - 1.7
   - tip
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 language: go
 go:
-- 1.5
+  - 1.5
+  - 1.6
+  - 1.7
+  - tip
 script:
-- make lint
-- make test
+  - make lint
+  - make test
 after_script:
-- make cover
+  - make cover

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2015 Songmu
+Copyright (c) 2017 Songmu
 
 MIT License
 

--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,6 @@ test: deps
 
 deps:
 	go get -d -v -t ./...
-	go get github.com/golang/lint/golint
-	go get golang.org/x/tools/cmd/vet
-	go get golang.org/x/tools/cmd/cover
 	go get github.com/mattn/goveralls
 
 LINT_RET = .golint.txt


### PR DESCRIPTION
@Songmu 

It will be nicer if we can test newer versions of Go on CI while keeping 1.5 for backward compatibility.