### PR TITLE
add override command status option

### DIFF
--- a/horenso.go
+++ b/horenso.go
@@ -18,10 +18,11 @@ import (
 const version = "0.0.2"
 
 type opts struct {
-	Reporter  []string `short:"r" long:"reporter" required:"true" value-name:"/path/to/reporter.pl" description:"handler for reporting the result of the job"`
-	Noticer   []string `short:"n" long:"noticer" value-name:"/path/to/noticer.rb" description:"handler for noticing the start of the job"`
-	TimeStamp bool     `short:"T" long:"timestamp" description:"add timestamp to merged output"`
-	Tag       string   `short:"t" long:"tag" value-name:"job-name" description:"tag of the job"`
+	Reporter       []string `short:"r" long:"reporter" required:"true" value-name:"/path/to/reporter.pl" description:"handler for reporting the result of the job"`
+	Noticer        []string `short:"n" long:"noticer" value-name:"/path/to/noticer.rb" description:"handler for noticing the start of the job"`
+	TimeStamp      bool     `short:"T" long:"timestamp" description:"add timestamp to merged output"`
+	Tag            string   `short:"t" long:"tag" value-name:"job-name" description:"tag of the job"`
+	OverrideStatus bool     `short:"o" long:"override-status" description:"override command exit status, always exit 0"`
 }
 
 // Report is represents the result of the command
@@ -159,6 +160,9 @@ func Run(args []string) int {
 	r, err := o.run(cmdArgs)
 	if err != nil {
 		return wrapcommander.ResolveExitCode(err)
+	}
+	if o.OverrideStatus {
+		return 0
 	}
 	return *r.ExitCode
 }


### PR DESCRIPTION
I add override command status option to horenso.

Always returns 0 even if the status of command is other than 0 when set `--override-status` option.

But I feel this option name is not quite right...
Other ideas is `--override-cmd-status`, `--ignore-cmd-status`. However 3 words is too long for option name 😕 

What do you think this option name?