### PR TITLE
Add verbose option to output `horenso` itself log output

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ wrapper shell.
 
 ## result JSON
 
-The reporters and noticers are accept a result JSON via STDIN that reports command result like following.
+The reporters and noticers accept a result JSON via STDIN that reports command result like following.
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Application Options:
   -T, --timestamp                         add timestamp to merged output
   -t, --tag=job-name                      tag of the job
   -o, --override-status                   override command exit status, always exit 0
+  -v, --verbose                           verbose output. it can be stacked like -vv for more detailed log
 ```
 
 Handlers are should be an executable or command line string. You can specify multiple reporters and noticers.

--- a/horenso.go
+++ b/horenso.go
@@ -24,7 +24,7 @@ type horenso struct {
 	TimeStamp      bool     `short:"T" long:"timestamp" description:"add timestamp to merged output"`
 	Tag            string   `short:"t" long:"tag" value-name:"job-name" description:"tag of the job"`
 	OverrideStatus bool     `short:"o" long:"override-status" description:"override command exit status, always exit 0"`
-	Verbose        []bool   `short:"v" long:"verbose" description:"verbose output"`
+	Verbose        []bool   `short:"v" long:"verbose" description:"verbose output. it can be stacked like -vv for more detailed log"`
 
 	outStream, errStream io.Writer
 }

--- a/horenso.go
+++ b/horenso.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"os/exec"
 	"runtime"
@@ -22,6 +23,7 @@ type horenso struct {
 	TimeStamp      bool     `short:"T" long:"timestamp" description:"add timestamp to merged output"`
 	Tag            string   `short:"t" long:"tag" value-name:"job-name" description:"tag of the job"`
 	OverrideStatus bool     `short:"o" long:"override-status" description:"override command exit status, always exit 0"`
+	Verbose        []bool   `short:"v" long:"verbose" description:"verbose output"`
 }
 
 // Report is represents the result of the command
@@ -135,17 +137,20 @@ func now() *time.Time {
 }
 
 func parseArgs(args []string) (*flags.Parser, *horenso, []string, error) {
-	o := &horenso{}
-	p := flags.NewParser(o, flags.Default)
+	ho := &horenso{}
+	p := flags.NewParser(ho, flags.Default)
 	p.Usage = fmt.Sprintf(`--reporter /path/to/reporter.pl -- /path/to/job [...]
 
 Version: %s (rev: %s/%s)`, version, revision, runtime.Version())
 	rest, err := p.ParseArgs(args)
-	return p, o, rest, err
+	return p, ho, rest, err
 }
 
 // Run the horenso
 func Run(args []string) int {
+	log.SetPrefix("[horenso] ")
+	log.SetFlags(0)
+
 	p, ho, cmdArgs, err := parseArgs(args)
 	if err != nil || len(cmdArgs) < 1 {
 		if ferr, ok := err.(*flags.Error); !ok || ferr.Type != flags.ErrHelp {

--- a/horenso_test.go
+++ b/horenso_test.go
@@ -31,7 +31,7 @@ func TestRun(t *testing.T) {
 	noticeReport := temp()
 	fname := temp()
 	fname2 := temp()
-	_, o, cmdArgs, err := parseArgs([]string{
+	_, ho, cmdArgs, err := parseArgs([]string{
 		"--noticer",
 		"go run testdata/reporter.go " + noticeReport,
 		"-n", "invalid",
@@ -45,7 +45,10 @@ func TestRun(t *testing.T) {
 	if err != nil {
 		t.Errorf("err should be nil but: %s", err)
 	}
-	r, err := o.run(cmdArgs)
+	ho.errStream = ioutil.Discard
+	ho.outStream = ioutil.Discard
+
+	r, err := ho.run(cmdArgs)
 	if err != nil {
 		t.Errorf("err should be nil but: %s", err)
 	}
@@ -109,7 +112,7 @@ func TestRunHugeOutput(t *testing.T) {
 	noticeReport := temp()
 	fname := temp()
 	fname2 := temp()
-	_, o, cmdArgs, err := parseArgs([]string{
+	_, ho, cmdArgs, err := parseArgs([]string{
 		"--noticer",
 		"go run testdata/reporter.go " + noticeReport,
 		"-n", "invalid",
@@ -123,7 +126,10 @@ func TestRunHugeOutput(t *testing.T) {
 	if err != nil {
 		t.Errorf("err should be nil but: %s", err)
 	}
-	r, err := o.run(cmdArgs)
+	ho.errStream = ioutil.Discard
+	ho.outStream = ioutil.Discard
+
+	r, err := ho.run(cmdArgs)
 	if err != nil {
 		t.Errorf("err should be nil but: %s", err)
 	}

--- a/log.go
+++ b/log.go
@@ -12,15 +12,19 @@ const (
 	mute loglevel = iota
 	warn
 	info
+	debug
 )
+
+func (ho *horenso) logLevel() loglevel {
+	return loglevel(len(ho.Verbose))
+}
 
 func (ho *horenso) logf(lv loglevel, format string, a ...interface{}) {
 	ho.log(lv, fmt.Sprintf(format, a...))
 }
 
 func (ho *horenso) log(lv loglevel, str string) {
-	logLv := loglevel(len(ho.Verbose))
-	if logLv < lv || lv <= mute {
+	if ho.logLevel() < lv || lv <= mute {
 		return
 	}
 	if !strings.HasSuffix(str, "\n") {

--- a/log.go
+++ b/log.go
@@ -1,0 +1,30 @@
+package horenso
+
+import (
+	"fmt"
+	"log"
+	"strings"
+)
+
+type loglevel int
+
+const (
+	mute loglevel = iota
+	warn
+	info
+)
+
+func (ho *horenso) logf(lv loglevel, format string, a ...interface{}) {
+	ho.log(lv, fmt.Sprintf(format, a...))
+}
+
+func (ho *horenso) log(lv loglevel, str string) {
+	logLv := loglevel(len(ho.Verbose))
+	if logLv < lv || lv <= mute {
+		return
+	}
+	if !strings.HasSuffix(str, "\n") {
+		str += "\n"
+	}
+	log.Print(str)
+}


### PR DESCRIPTION
By default, horenso doesn't out itself log output, only outs the child command outputs.

This is to avoid disturbing the behavior of existing commands, but since it does not output failure of reporters or noticers, it is troublesome on development or debugging.

To solve this problem, I added a verbose(-v|--verbose) option to output detailed logs.

Options can be stacked like -vv.

If v is one, it outputs warning logs when each time a strange behavior is being executed. If there are two or more v, it outputs a detailed information log for each phase being executed.

It closes #12.