### PR TITLE
add --log option

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -27,6 +27,22 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:8654122ef85f2bc03859b0a7ea2d36c9965888689cdac7640cceaa6edb11cff6"
+  name = "github.com/lestrrat-go/strftime"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "8b31f9c59b0feb56c456ce49a7b3d2b2e93a6f18"
+
+[[projects]]
+  digest = "1:cf31692c14422fa27c83a05292eb5cbe0fb2775972e8f1f8446a71549bd8980b"
+  name = "github.com/pkg/errors"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "ba968bfe8b2f7e042a574c888954fccecfa385b4"
+  version = "v0.8.1"
+
+[[projects]]
+  branch = "master"
   digest = "1:b521f10a2d8fa85c04a8ef4e62f2d1e14d303599a55d64dabf9f5a02f84d35eb"
   name = "golang.org/x/sync"
   packages = ["errgroup"]
@@ -40,6 +56,7 @@
     "github.com/Songmu/wrapcommander",
     "github.com/jessevdk/go-flags",
     "github.com/kballard/go-shellquote",
+    "github.com/lestrrat-go/strftime",
     "golang.org/x/sync/errgroup",
   ]
   solver-name = "gps-cdcl"

--- a/README.md
+++ b/README.md
@@ -31,12 +31,15 @@ Usage:
   horenso --reporter /path/to/reporter.pl -- /path/to/job [...]
 
 Application Options:
-  -r, --reporter=/path/to/reporter.pl     handler for reporting the result of the job
-  -n, --noticer='ruby/path/to/noticer.rb' handler for noticing the start of the job
-  -T, --timestamp                         add timestamp to merged output
-  -t, --tag=job-name                      tag of the job
-  -o, --override-status                   override command exit status, always exit 0
-  -v, --verbose                           verbose output. it can be stacked like -vv for more detailed log
+  -r, --reporter=/path/to/reporter.pl      handler for reporting the result of the job
+  -n, --noticer='ruby /path/to/noticer.rb' handler for noticing the start of the job
+  -T, --timestamp                          add timestamp to merged output
+  -t, --tag=job-name                       tag of the job
+  -o, --override-status                    override command exit status, always exit 0
+  -v, --verbose                            verbose output. it can be stacked like -vv for
+                                           more detailed log
+  -l, --log=logfile-path                   logfile path. The strftime format like
+                                           '%Y%m%d.log' is available.
 ```
 
 Handlers are should be an executable or command line string. You can specify multiple reporters and noticers.

--- a/horenso.go
+++ b/horenso.go
@@ -21,12 +21,12 @@ import (
 
 type horenso struct {
 	Reporter       []string `short:"r" long:"reporter" required:"true" value-name:"/path/to/reporter.pl" description:"handler for reporting the result of the job"`
-	Noticer        []string `short:"n" long:"noticer" value-name:"/path/to/noticer.rb" description:"handler for noticing the start of the job"`
+	Noticer        []string `short:"n" long:"noticer" value-name:"'ruby /path/to/noticer.rb'" description:"handler for noticing the start of the job"`
 	TimeStamp      bool     `short:"T" long:"timestamp" description:"add timestamp to merged output"`
 	Tag            string   `short:"t" long:"tag" value-name:"job-name" description:"tag of the job"`
 	OverrideStatus bool     `short:"o" long:"override-status" description:"override command exit status, always exit 0"`
 	Verbose        []bool   `short:"v" long:"verbose" description:"verbose output. it can be stacked like -vv for more detailed log"`
-	Logfile        string   `short:"l" long:"log" description:"logfile path. available strftime format like '%Y%m%d.log'"`
+	Logfile        string   `short:"l" long:"log" value-name:"logfile-path" description:"logfile path. The strftime format like '%Y%m%d.log' is available."`
 
 	outStream, errStream io.Writer
 }


### PR DESCRIPTION
Now we can specify log file path by using the `--log|-l` option.

The `strftime` format like '%Y%m%d.log' is available.