### PR TITLE
Fix Windows style path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ bump: devel-deps
 
 crossbuild: devel-deps
 	GO111MODULE=on goxz -pv=v$(VERSION) -build-ldflags=$(BUILD_LDFLAGS) \
-	  -os=linux,darwin,freebsd -arch=386,amd64 \
+	  -os=linux,darwin,freebsd,windows -arch=386,amd64 \
 	  -d=./dist/v$(VERSION) ./cmd/horenso
 
 upload:

--- a/horenso.go
+++ b/horenso.go
@@ -257,14 +257,24 @@ func (ho *horenso) appendOut(base, out string) string {
 	return base + indent + strings.Replace("Output:\n"+out, "\n", "\n"+indent, -1)
 }
 
-func (ho *horenso) splitHandlerCmdStr(cmdStr string) []string {
-	args := strings.Split(cmdStr, " ")
-	return args
+func (ho *horenso) splitHandlerCmdStr(cmdStr string) ([]string, error) {
+	switch runtime.GOOS {
+	case "windows":
+		args := strings.Split(cmdStr, " ")
+		return args, nil
+	default:
+		args, err := shellquote.Split(cmdStr)
+		return args, err
+	}
 }
 
 func (ho *horenso) runHandler(cmdStr string, json []byte) error {
 	ho.logf(info, "starting to run the handler %q", cmdStr)
-	args := ho.splitHandlerCmdStr(cmdStr)
+	args, err := ho.splitHandlerCmdStr(cmdStr)
+	if err != nil || len(args) < 1 {
+		ho.logf(warn, "failed to run the handler %q: invalid handler arguments", cmdStr)
+		return fmt.Errorf("invalid handler: %q", cmdStr)
+	}
 	cmd := exec.Command(args[0], args[1:]...)
 	stdinPipe, _ := cmd.StdinPipe()
 	var b bytes.Buffer
@@ -278,7 +288,7 @@ func (ho *horenso) runHandler(cmdStr string, json []byte) error {
 	}
 	stdinPipe.Write(json)
 	stdinPipe.Close()
-	err := cmd.Wait()
+	err = cmd.Wait()
 	if err != nil || ho.logLevel() >= info {
 		var logoutput string
 		lv := info

--- a/horenso.go
+++ b/horenso.go
@@ -257,18 +257,14 @@ func (ho *horenso) appendOut(base, out string) string {
 	return base + indent + strings.Replace("Output:\n"+out, "\n", "\n"+indent, -1)
 }
 
-func (ho *horenso) splitHandlerCmdStr(cmdStr string) ([]string, error) {
-	args, err := shellquote.Split(cmdStr)
-	return args, err
+func (ho *horenso) splitHandlerCmdStr(cmdStr string) []string {
+	args := strings.Split(cmdStr, " ")
+	return args
 }
 
 func (ho *horenso) runHandler(cmdStr string, json []byte) error {
 	ho.logf(info, "starting to run the handler %q", cmdStr)
-	args, err := ho.splitHandlerCmdStr(cmdStr)
-	if err != nil || len(args) < 1 {
-		ho.logf(warn, "failed to run the handler %q: invalid handler arguments", cmdStr)
-		return fmt.Errorf("invalid handler: %q", cmdStr)
-	}
+	args := ho.splitHandlerCmdStr(cmdStr)
 	cmd := exec.Command(args[0], args[1:]...)
 	stdinPipe, _ := cmd.StdinPipe()
 	var b bytes.Buffer
@@ -282,7 +278,7 @@ func (ho *horenso) runHandler(cmdStr string, json []byte) error {
 	}
 	stdinPipe.Write(json)
 	stdinPipe.Close()
-	err = cmd.Wait()
+	err := cmd.Wait()
 	if err != nil || ho.logLevel() >= info {
 		var logoutput string
 		lv := info

--- a/horenso.go
+++ b/horenso.go
@@ -257,9 +257,14 @@ func (ho *horenso) appendOut(base, out string) string {
 	return base + indent + strings.Replace("Output:\n"+out, "\n", "\n"+indent, -1)
 }
 
+func (ho *horenso) splitHandlerCmdStr(cmdStr string) ([]string, error) {
+	args, err := shellquote.Split(cmdStr)
+	return args, err
+}
+
 func (ho *horenso) runHandler(cmdStr string, json []byte) error {
 	ho.logf(info, "starting to run the handler %q", cmdStr)
-	args, err := shellquote.Split(cmdStr)
+	args, err := ho.splitHandlerCmdStr(cmdStr)
 	if err != nil || len(args) < 1 {
 		ho.logf(warn, "failed to run the handler %q: invalid handler arguments", cmdStr)
 		return fmt.Errorf("invalid handler: %q", cmdStr)

--- a/horenso_test.go
+++ b/horenso_test.go
@@ -340,10 +340,7 @@ func TestSplitHandlerCmdStr(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			for _, r := range tt.ho.Reporter {
-				args, err := tt.ho.splitHandlerCmdStr(r)
-				if err != nil {
-					t.Errorf("err should be nil but: %s", err)
-				}
+				args := tt.ho.splitHandlerCmdStr(r)
 				if !reflect.DeepEqual(tt.expect, args) {
 					t.Errorf("should be %v but: %v", tt.expect, args)
 				}

--- a/horenso_test.go
+++ b/horenso_test.go
@@ -315,6 +315,43 @@ func TestRunHugeOutput(t *testing.T) {
 	}
 }
 
+func TestSplitHandlerCmdStr(t *testing.T) {
+	tests := []struct {
+		name   string
+		ho     horenso
+		expect []string
+	}{
+		{
+			name: "Linux style path",
+			ho: horenso{
+				Reporter: []string{"go run testdata/reporter.go arg1 arg2"},
+			},
+			expect: []string{"go", "run", "testdata/reporter.go", "arg1", "arg2"},
+		},
+		{
+			name: "Windows style path",
+			ho: horenso{
+				Reporter: []string{`go run C:\testdata\reporter.go arg1 arg2`},
+			},
+			expect: []string{"go", "run", `C:\testdata\reporter.go`, "arg1", "arg2"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, r := range tt.ho.Reporter {
+				args, err := tt.ho.splitHandlerCmdStr(r)
+				if err != nil {
+					t.Errorf("err should be nil but: %s", err)
+				}
+				if !reflect.DeepEqual(tt.expect, args) {
+					t.Errorf("should be %v but: %v", tt.expect, args)
+				}
+			}
+		})
+	}
+}
+
 func equalTimePtr(t1, t2 *time.Time) bool {
 	if t1 == nil && t2 == nil {
 		return true

--- a/horenso_test.go
+++ b/horenso_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"reflect"
 	"regexp"
+	"runtime"
 	"testing"
 	"time"
 )
@@ -329,6 +330,13 @@ func TestSplitHandlerCmdStr(t *testing.T) {
 			expect: []string{"go", "run", "testdata/reporter.go", "arg1", "arg2"},
 		},
 		{
+			name: "Linux style path sh -c `cmd`",
+			ho: horenso{
+				Reporter: []string{`sh -c go run testdata/reporter.go arg1 arg2`},
+			},
+			expect: []string{"sh", "-c", "go", "run", "testdata/reporter.go", "arg1", "arg2"},
+		},
+		{
 			name: "Windows style path",
 			ho: horenso{
 				Reporter: []string{`go run C:\testdata\reporter.go arg1 arg2`},
@@ -339,8 +347,14 @@ func TestSplitHandlerCmdStr(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			if tt.name == "Windows style path" && runtime.GOOS != "windows" {
+				return
+			}
 			for _, r := range tt.ho.Reporter {
-				args := tt.ho.splitHandlerCmdStr(r)
+				args, err := tt.ho.splitHandlerCmdStr(r)
+				if err != nil {
+					t.Errorf("err should be nil but: %s", err)
+				}
 				if !reflect.DeepEqual(tt.expect, args) {
 					t.Errorf("should be %v but: %v", tt.expect, args)
 				}


### PR DESCRIPTION
This patch will resolve an issue of https://github.com/Songmu/horenso/issues/31. The PR has 3 commits.

- https://github.com/hiroakis/horenso/pull/2/commits/756a56b27beb32e195e74c31c3935ff14210bde0: Make testable for that issue.
- https://github.com/hiroakis/horenso/pull/2/commits/c4777bd08ab2c71e8121aae6a240dfaf62abce83: Testing (has a failure case)
```
horenso = go test -run TestSplitHandlerCmdStr
--- FAIL: TestSplitHandlerCmdStr (0.00s)
    --- FAIL: TestSplitHandlerCmdStr/Windows_style_path (0.00s)
        horenso_test.go:348: should be [go run C:\testdata\reporter.go arg1 arg2] but: [go run C:testdatareporter.go arg1 arg2]
FAIL
exit status 1
FAIL    github.com/hiroakis/horenso     0.253s
```
- https://github.com/hiroakis/horenso/pull/2/commits/9f10576bfa9dea1a35f6bebbfadb54cd3cab8220: Fix the issue.